### PR TITLE
Version 53.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ build:
 
 requirements:
   host:
+    - flit-core >=3.2
     - pip
-    - pytest-runner
     - python >=3.6
   run:
     - cffi >=0.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,18 +22,15 @@ requirements:
     - pytest-runner
     - python >=3.6
   run:
-    - cairo >=1.15.4
-    - cairocffi >=0.9.0
-    - cairosvg >=2.4.0
     - cffi >=0.6
     - cssselect2 >=0.1
-    - gdk-pixbuf >=2.25.0
-    - html5lib >=0.999999999
+    - fonttools >=4.0.0
+    - html5lib >=1.0.1
+    - pango >=1.44.0
     - pillow >=4.0.0
-    - pango >=1.38.0
+    - pydyf >=0.0.3
     - pyphen >=0.9.1
     - python >=3.6
-    - setuptools >=39.2.0
     - tinycss2 >=1.0.0
     - glib  # Temporary, see https://github.com/conda-forge/weasyprint-feedstock/issues/23
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "WeasyPrint" %}
-{% set version = "52.5" %}
+{% set version = "53.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/Kozea/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 6571d36661e8d8c2bc4baf6347700284ac00e6c4ebbcdcad2ea68c074ce6325b
+  sha256: 004c9fcf7c73f2c0a45f63d990eaa660efaf9e47973d572082c8af8e5562f4a6
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - weasyprint = weasyprint.__main__:main


### PR DESCRIPTION
Built on top of https://github.com/conda-forge/weasyprint-feedstock/pull/25, with updated dependencies.

We currently miss the pydyf package. If someone is interested in adding this package…