### PR TITLE
Add missing gtk+ dependency on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 1
-  noarch: python
   entry_points:
     - weasyprint = weasyprint.__main__:main
   script: {{ PYTHON }} -m pip install {{ name|lower }}-{{ version }}-py3-none-any.whl -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 1
+  skip: True  # [py<37]
   entry_points:
     - weasyprint = weasyprint.__main__:main
   script: {{ PYTHON }} -m pip install {{ name|lower }}-{{ version }}-py3-none-any.whl -vv
@@ -28,7 +29,7 @@ requirements:
     - pillow >=9.1.0
     - pydyf >=0.8.0
     - pyphen >=0.9.1
-    - python >=3.7
+    - python
     - tinycss2 >=1.0.0
     - glib  # Temporary, see https://github.com/conda-forge/weasyprint-feedstock/issues/23
     - gtk3  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 55227e5e44f5f34bc9cec651329bd38d063ef7d29151d4b058d4af1ca943d4a7
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - weasyprint = weasyprint.__main__:main
@@ -32,6 +32,7 @@ requirements:
     - python >=3.7
     - tinycss2 >=1.0.0
     - glib  # Temporary, see https://github.com/conda-forge/weasyprint-feedstock/issues/23
+    - gtk3  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
     - cffi >=0.6
     - cssselect2 >=0.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Weasyprint documentation states that  [GTK+ is required on Windows](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#windows). This PR adds gtk3 as dependency on Windows. 

This fixes the `OSError: cannot load library 'gobject-2.0-0'"`([link](https://github.com/assafelovic/gpt-researcher/issues/166)) error I get when using the current package. 
